### PR TITLE
Change content disposition to inline on mooc.helsinki.fi too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inline-moodle-pdf-extension
 
-Chrome extension which makes the University of Helsinki Moodle show PDF downloads in a new tab instead of downloading them.
+Chrome extension which makes the University of Helsinki Moodle & Mooc platform show PDF downloads in a new tab instead of downloading them.
 
 [**View on Chrome Web Store →**](https://chrome.google.com/webstore/detail/inline-pdfs-for-uh-moodle/ilddijpognoadbfmlgnkgdogdciogmjn)
 

--- a/background.js
+++ b/background.js
@@ -55,6 +55,6 @@ chrome.webRequest.onHeadersReceived.addListener(
 
     return { responseHeaders: newHeaders };
   },
-  { urls: ["https://moodle.helsinki.fi/*"] },
+  { urls: ["https://moodle.helsinki.fi/*", "https://mooc.helsinki.fi/*"] },
   ["blocking", "responseHeaders"]
 );

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "https://moodle.helsinki.fi/*"
+    "https://moodle.helsinki.fi/*",
+    "https://mooc.helsinki.fi/*"
   ],
   "icons": {
     "16": "icon16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Inline PDFs for UH Moodle",
   "version": "1.19.1",
-  "description": "View University of Helsinki Moodle PDF downloads in Chrome instead of downloading to disk",
+  "description": "View University of Helsinki Moodle and Mooc PDF downloads in Chrome instead of downloading to disk",
   "manifest_version": 2,
   "background": {
     "scripts": ["background.js"]


### PR DESCRIPTION
Adds support for mooc.helsinki.fi.

Only problem with this feature is that this extensions scope grows outside moodle.helsinki.fi, which means that the extension should probably be renamed.